### PR TITLE
Fix argument type

### DIFF
--- a/evil-jumper.el
+++ b/evil-jumper.el
@@ -273,8 +273,8 @@ Note: The value of `evil-jumper-file' must also be non-nil."
     (progn
       (remove-hook 'next-error-hook #'evil-jumper--set-jump)
       (remove-hook 'window-configuration-change-hook #'evil-jumper--window-configuration-hook)
-      (ad-remove-advice 'evil-set-jump 'after #'evil-jumper--evil-set-jump)
-      (ad-remove-advice 'switch-to-buffer 'before #'evil-jumper--switch-to-buffer)))
+      (ad-remove-advice 'evil-set-jump 'after 'evil-jumper--evil-set-jump)
+      (ad-remove-advice 'switch-to-buffer 'before 'evil-jumper--switch-to-buffer)))
   (evil-normalize-keymaps))
 
 ;;;###autoload


### PR DESCRIPTION
I got following byte-compile warnings with original code.

```
Entering directory `/home/syohei/tmp/test/evil-jumper/'

In end of data:
evil-jumper.el:298:1:Warning: the following functions are not known to be defined\
:
    evil-jumper--evil-set-jump, evil-jumper--switch-to-buffer
```

Third argument of 'ad-remove-advice' is a name, not a function. (Hash quote(`#'`) is not necessary).
