### PR TITLE
Integrate with savehist

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 evil-jumper
 ===========
 
-evil-jumper is an add-on for [evil-mode][1] which replaces the implementation of the jump list such that it mimics more closely with Vim's behavior. Specifically, it will jump across buffer boundaries and revive dead buffers if necessary. The jump list can also be persisted to a file and restored between sessions.
+evil-jumper is an add-on for [evil-mode][1] which replaces the implementation of the jump list such that it mimics more closely with Vim's behavior. Specifically, it will jump across buffer boundaries and revive dead buffers if necessary. The jump list can also be persisted to history file using `savehist` and restored between sessions.
 
 installation
 ============

--- a/evil-jumper.el
+++ b/evil-jumper.el
@@ -35,7 +35,8 @@
 ;; implementation of the jump list such that it mimics more closely
 ;; with Vim's behavior. Specifically, it will jump across buffer
 ;; boundaries and revive dead buffers if necessary. The jump list can
-;; also be persisted to a file and restored between sessions.
+;; also be persisted to history file using `savehist' and restored
+;; between sessions.
 ;;
 ;; Install:
 ;;
@@ -43,7 +44,7 @@
 ;;
 ;; Usage:
 ;;
-;; (global-evil-jumper-mode)
+;; (evil-jumper-mode 1)
 
 ;;; Code:
 

--- a/evil-jumper.el
+++ b/evil-jumper.el
@@ -70,25 +70,6 @@
   :type '(repeat string)
   :group 'evil-jumper)
 
-(defcustom evil-jumper-plug-into-savehist t
-  "Rely on savehist for persistent jump list instead of `evil-jumper-file'.
-
-Note: The interval can be set with `savehist-autosave-interval' accordingly."
-  :type 'boolean
-  :group 'evil-jumper)
-
-(defcustom evil-jumper-file nil
-  "The location of the file to save/load the jump list."
-  :type 'string
-  :group 'evil-jumper)
-
-(defcustom evil-jumper-auto-save-interval 0
-  "If positive, specifies the interval in seconds to persist the jump list.
-
-Note: The value of `evil-jumper-file' must also be non-nil."
-  :type 'integer
-  :group 'evil-jumper)
-
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (defvar evil-jumper--jumping nil)
@@ -132,50 +113,24 @@ Note: The value of `evil-jumper-file' must also be non-nil."
 
 (defun evil-jumper--read-file ()
   "Restores the jump list from the persisted file."
-  (if evil-jumper-plug-into-savehist
-      (evil-jumper--set-window-jump-list evil-jumper--jump-list)
-    (when (file-exists-p evil-jumper-file)
-      (let ((lines (with-temp-buffer
-                     (insert-file-contents evil-jumper-file)
-                     (split-string (buffer-string) "\n" t)))
-            (jumps nil))
-        (dolist (line lines)
-          (let* ((parts (split-string line " "))
-                 (pos (string-to-number (car parts)))
-                 (file-name (cadr parts)))
-            (push (list pos file-name) jumps)))
-        (evil-jumper--set-window-jump-list jumps)))))
+  (evil-jumper--set-window-jump-list evil-jumper--jump-list))
 
 (defun evil-jumper--write-file ()
   "Saves the current contents of the jump list to a persisted file."
-  (if evil-jumper-plug-into-savehist
-      (setq evil-jumper--jump-list
-            (cl-remove-if-not #'identity
-                              (mapcar #'(lambda (jump)
-                                          (let* ((mark (car jump))
-                                                 (pos (if (markerp mark)
-                                                          (marker-position mark)
-                                                        mark))
-                                                 (file-name (cadr jump)))
-                                            (if (and (not (file-remote-p file-name))
-                                                     (file-exists-p file-name)
-                                                     pos)
-                                                (list pos file-name)
-                                              nil)))
-                                      (evil-jumper--get-window-jump-list))))
-    (with-temp-file evil-jumper-file
-      (let ((jumps (evil-jumper--get-window-jump-list)))
-        (dolist (jump jumps)
-          (let* ((mark (car jump))
-                 (pos (if (markerp mark)
-                          (marker-position mark)
-                        mark))
-                 (file-name (cadr jump)))
-            (when (and (file-exists-p file-name) pos)
-              (insert (format "%d" pos))
-              (insert " ")
-              (insert file-name)
-              (insert "\n"))))))))
+  (setq evil-jumper--jump-list
+        (cl-remove-if-not #'identity
+                          (mapcar #'(lambda (jump)
+                                      (let* ((mark (car jump))
+                                             (pos (if (markerp mark)
+                                                      (marker-position mark)
+                                                    mark))
+                                             (file-name (cadr jump)))
+                                        (if (and (not (file-remote-p file-name))
+                                                 (file-exists-p file-name)
+                                                 pos)
+                                            (list pos file-name)
+                                          nil)))
+                                  (evil-jumper--get-window-jump-list)))))
 
 (defun evil-jumper--jump-to-index (idx)
   (let ((target-list (evil-jumper--get-window-jump-list)))
@@ -274,17 +229,12 @@ Note: The value of `evil-jumper-file' must also be non-nil."
              evil-jumper--window-jumps)))
 
 (defun evil-jumper--init-file ()
-  (when (and (not evil-jumper--wired)
-             (or evil-jumper-plug-into-savehist
-                 evil-jumper-file))
+  (unless evil-jumper--wired
     (evil-jumper--read-file)
     (defadvice save-buffers-kill-emacs (before evil-jumper--save-buffers-kill-emacs activate)
       (evil-jumper--write-file))
-    (when evil-jumper-plug-into-savehist
-      (push 'evil-jumper--jump-list savehist-additional-variables)
-      (add-hook 'savehist-save-hook #'evil-jumper--write-file))
-    (when (> evil-jumper-auto-save-interval 0)
-      (run-with-timer evil-jumper-auto-save-interval evil-jumper-auto-save-interval #'evil-jumper--write-file))
+    (push 'evil-jumper--jump-list savehist-additional-variables)
+    (add-hook 'savehist-save-hook #'evil-jumper--write-file)
     (setq evil-jumper--wired t)))
 
 ;;;###autoload

--- a/evil-jumper.el
+++ b/evil-jumper.el
@@ -230,8 +230,10 @@
     (evil-jumper--set-window-jump-list evil-jumper--jump-list)
     (defadvice save-buffers-kill-emacs (before evil-jumper--save-buffers-kill-emacs activate)
       (evil-jumper--savehist))
-    (push 'evil-jumper--jump-list savehist-additional-variables)
-    (add-hook 'savehist-save-hook #'evil-jumper--savehist)
+    (eval-after-load 'savehist
+      '(progn
+         (push 'evil-jumper--jump-list savehist-additional-variables)
+         (add-hook 'savehist-save-hook #'evil-jumper--savehist)))
     (setq evil-jumper--wired t)))
 
 ;;;###autoload

--- a/evil-jumper.el
+++ b/evil-jumper.el
@@ -111,12 +111,8 @@
   (let ((struct (evil-jumper--get-current)))
     (setf (evil-jumper-jump-jumps struct) list)))
 
-(defun evil-jumper--read-file ()
-  "Restores the jump list from the persisted file."
-  (evil-jumper--set-window-jump-list evil-jumper--jump-list))
-
-(defun evil-jumper--write-file ()
-  "Saves the current contents of the jump list to a persisted file."
+(defun evil-jumper--savehist ()
+  "Saves the current contents of the jump list to history file."
   (setq evil-jumper--jump-list
         (cl-remove-if-not #'identity
                           (mapcar #'(lambda (jump)
@@ -228,13 +224,13 @@
                  (remhash key evil-jumper--window-jumps)))
              evil-jumper--window-jumps)))
 
-(defun evil-jumper--init-file ()
+(defun evil-jumper--init-savehist ()
   (unless evil-jumper--wired
-    (evil-jumper--read-file)
+    (evil-jumper--set-window-jump-list evil-jumper--jump-list)
     (defadvice save-buffers-kill-emacs (before evil-jumper--save-buffers-kill-emacs activate)
-      (evil-jumper--write-file))
+      (evil-jumper--savehist))
     (push 'evil-jumper--jump-list savehist-additional-variables)
-    (add-hook 'savehist-save-hook #'evil-jumper--write-file)
+    (add-hook 'savehist-save-hook #'evil-jumper--savehist)
     (setq evil-jumper--wired t)))
 
 ;;;###autoload
@@ -248,7 +244,7 @@
             map)
   (if evil-jumper-mode
       (progn
-        (evil-jumper--init-file)
+        (evil-jumper--init-savehist)
         (add-hook 'next-error-hook #'evil-jumper--set-jump)
         (add-hook 'window-configuration-change-hook #'evil-jumper--window-configuration-hook)
         (defadvice evil-set-jump (after evil-jumper--evil-set-jump activate)


### PR DESCRIPTION
The jump list can be saved by `savehist` in `/.emacs.d/history` by default.