### PR TITLE
Consider windows across all frames

### DIFF
--- a/evil-jumper.el
+++ b/evil-jumper.el
@@ -199,14 +199,8 @@
     (evil-motion-loop (nil count)
       (evil-jumper--jump-to-index (- idx 1)))))
 
-(defun all-windows ()
-  "Get a list of all of the windows across all frames"
-  (let* ((frames (frame-list))
-         (nested-windows (mapcar 'window-list frames)))
-    (apply 'append nested-windows)))
-
 (defun evil-jumper--window-configuration-hook (&rest args)
-  (let* ((window-list (all-windows))
+  (let* ((window-list (window-list-1 nil nil t))
          (existing-window (selected-window))
          (new-window (previous-window)))
     (when (and (not (eq existing-window new-window))

--- a/evil-jumper.el
+++ b/evil-jumper.el
@@ -202,7 +202,7 @@
 (defun all-windows ()
   "Get a list of all of the windows across all frames"
   (let* ((frames (frame-list))
-	 (nested-windows (mapcar 'window-list frames)))
+         (nested-windows (mapcar 'window-list frames)))
     (apply 'append nested-windows)))
 
 (defun evil-jumper--window-configuration-hook (&rest args)

--- a/evil-jumper.el
+++ b/evil-jumper.el
@@ -199,8 +199,14 @@
     (evil-motion-loop (nil count)
       (evil-jumper--jump-to-index (- idx 1)))))
 
+(defun all-windows ()
+  "Get a list of all of the windows across all frames"
+  (let* ((frames (frame-list))
+	 (nested-windows (mapcar 'window-list frames)))
+    (apply 'append nested-windows)))
+
 (defun evil-jumper--window-configuration-hook (&rest args)
-  (let* ((window-list (window-list))
+  (let* ((window-list (all-windows))
          (existing-window (selected-window))
          (new-window (previous-window)))
     (when (and (not (eq existing-window new-window))


### PR DESCRIPTION
I use an admittedly weird workflow of using multiple frames in `-nw` emacs.  Currently, when I accumulate a jump-list in a window in one frame, then switch to a different frame, then switch back to the original frame, I lose the original jump-list.

I think this is happening because `(window-list)` returns the windows for the current frame only, so the code to delete obsolete window jump-lists does not consider windows that might be in other frames.

This PR adds a function to get a window list from all frames, and use that in the window configuration hook.  It seems to work for me, but I'm new to emacs and elisp, so go easy on me :smile: 