### PR TITLE
Use remap to define keys

### DIFF
--- a/evil-jumper.el
+++ b/evil-jumper.el
@@ -236,9 +236,9 @@
   "Global minor mode for vim jumplist emulation."
   :global t
   :keymap (let ((map (make-sparse-keymap)))
-            (evil-define-key 'normal map (kbd "C-o") #'evil-jumper/backward)
+            (evil-define-key 'normal map [remap evil-jump-backward] #'evil-jumper/backward)
             (when evil-want-C-i-jump
-              (evil-define-key 'normal map (kbd "C-i") #'evil-jumper/forward))
+              (evil-define-key 'normal map [remap evil-jump-forward] #'evil-jumper/forward))
             map)
   (if evil-jumper-mode
       (progn


### PR DESCRIPTION
Binding C-i and C-o using evil-define-key interferes with other minor
modes that use evil-define-key, especially when binding C-i (which is
the same key as TAB). This means that minor modes might need to turn off
evil-jumper to be able to bind to TAB. This is awkward because
evil-jumper is defined as a global minor mode, so turning it off means
disabling it everywhere. Using remap has the effect of dynamically
rebinding any occurrence of evil-jump-forward or evil-jump-backward.
Since these functions are in the evil-motion-state-map, this will not
interfere with the minor modes like the current ones do.