### PR TITLE
Remove guard for evil-want-C-i-jump

### DIFF
--- a/evil-jumper.el
+++ b/evil-jumper.el
@@ -242,8 +242,7 @@
   :global t
   :keymap (let ((map (make-sparse-keymap)))
             (evil-define-key 'normal map [remap evil-jump-backward] #'evil-jumper/backward)
-            (when evil-want-C-i-jump
-              (evil-define-key 'normal map [remap evil-jump-forward] #'evil-jumper/forward))
+            (evil-define-key 'normal map [remap evil-jump-forward] #'evil-jumper/forward)
             map)
   (if evil-jumper-mode
       (progn


### PR DESCRIPTION
It could be that someone bound evil-jump-forward to another key and then
wants to use evil-jumper in that case evil-want-C-i-jump would be nil
but evil-jump-forward is bound somewhere else. By removing the guard
this binding will automatically get remapped without extra effort.

When evil-jump-forward is not bound anywhere, the remap will not take
effect anyway, so it's harmless to remove the guard in this case.
